### PR TITLE
Add tRNS transparency for PNG images with color type 3

### DIFF
--- a/components/driver_framebuffer/png/png_reader.h
+++ b/components/driver_framebuffer/png/png_reader.h
@@ -32,6 +32,8 @@ enum lib_png_error_t {
 	LIB_PNG_ERROR_INVALID_DEFLATE_HEADER,
 	LIB_PNG_ERROR_INVALID_PNG_SCANLINE_TYPE,
 	LIB_PNG_ERROR_TOP,
+	LIB_PNG_ERROR_MULTIPLE_TRNS_FOUND,
+	LIB_PNG_ERROR_INVALID_TRNS_SIZE,
 };
 
 struct lib_png_chunk {
@@ -60,6 +62,8 @@ struct lib_png_reader {
 
 	uint8_t *palette;
 	int palette_len;
+	uint8_t *trns;
+	int trns_len;
 
 	uint8_t scanline_bpp; // 1, 2, 3, 4, 6 or 8
 	uint32_t scanline_width;


### PR DESCRIPTION
This PR adds support for parsing and using the tRNS PNG chunk to provide transparency for PNG images with color type 3 (using Palettes).
This is especially useful for png images with transparency that have been compressed with tools such as pngquant.
The code was tested on the MCH badge.