### PR TITLE
Fix small memory leak in png reader

### DIFF
--- a/components/driver_framebuffer/png/png_reader.c
+++ b/components/driver_framebuffer/png/png_reader.c
@@ -674,6 +674,10 @@ lib_png_destroy(struct lib_png_reader *pr)
 		free(pr->palette);
 	pr->palette = NULL;
 
+	if (pr->trns)
+		free(pr->trns);
+	pr->trns = NULL;
+
 	if (pr->scanline)
 		free(pr->scanline);
 	pr->scanline = NULL;


### PR DESCRIPTION
Not clear what the impact of this memory leak is, if any, but good to get rid of it regardless.