### PR TITLE
only allocate as much buffer as the PNG requires

### DIFF
--- a/components/driver_framebuffer/png/deflate_reader.c
+++ b/components/driver_framebuffer/png/deflate_reader.c
@@ -166,13 +166,14 @@ lib_deflate_init(struct lib_deflate_reader *dr, lib_reader_read_t read, void *re
 }
 
 struct lib_deflate_reader *
-lib_deflate_new(lib_reader_read_t read, void *read_p)
+lib_deflate_new(lib_reader_read_t read, void *read_p, int lb_capacity)
 {
-	struct lib_deflate_reader *dr = (struct lib_deflate_reader *) malloc(sizeof(struct lib_deflate_reader));
+	struct lib_deflate_reader *dr = (struct lib_deflate_reader *) malloc(sizeof(struct lib_deflate_reader)+lb_capacity);
 	if (unlikely(dr == NULL))
 		return NULL;
 
 	lib_deflate_init(dr, read, read_p);
+    dr->lb_capacity = lb_capacity;
 
 	return dr;
 }
@@ -401,8 +402,8 @@ lib_deflate_read(struct lib_deflate_reader *dr, uint8_t *buf, size_t buf_len)
 				size_t copylen = dr->copy_len;
 				if (copylen > buf_len - buf_pos)
 					copylen = buf_len - buf_pos;
-				if (copylen > 32768 - dr->lb_pos)
-					copylen = 32768 - dr->lb_pos;
+				if (copylen > dr->lb_capacity - dr->lb_pos)
+					copylen = dr->lb_capacity - dr->lb_pos;
 
 				uint8_t *rd_buf = &dr->look_behind[ dr->lb_pos ];
 				ssize_t res = dr->read(dr->read_p, rd_buf, copylen);
@@ -419,8 +420,8 @@ lib_deflate_read(struct lib_deflate_reader *dr, uint8_t *buf, size_t buf_len)
 				dr->copy_len -= copylen;
 
 				dr->lb_pos += copylen;
-				dr->lb_pos &= 32767;
-				if (dr->lb_size < 32768)
+				dr->lb_pos &= (dr->lb_capacity-1);
+				if (dr->lb_size < dr->lb_capacity)
 					dr->lb_size += copylen;
 			}
 			dr->state = LIB_DEFLATE_STATE_NEW_BLOCK;
@@ -437,8 +438,8 @@ lib_deflate_read(struct lib_deflate_reader *dr, uint8_t *buf, size_t buf_len)
 
 				dr->look_behind[ dr->lb_pos ] = token;
 				dr->lb_pos++;
-				dr->lb_pos &= 32767;
-				if (dr->lb_size < 32768)
+				dr->lb_pos &= (dr->lb_capacity-1);
+				if (dr->lb_size < dr->lb_capacity)
 					dr->lb_size++;
 			}
 			else if (token == 256)
@@ -502,18 +503,18 @@ lib_deflate_read(struct lib_deflate_reader *dr, uint8_t *buf, size_t buf_len)
 				// int copylen = dr->copy_len;
 				// copylen = buf_len - buf_pos if copylen > buf_len - buf_pos
 				// copylen = dr->copy_dist if copylen > dr->copy_dist
-				// copylen = 32768 - dr->lb_pos if copylen > 32768 - dr->lb_pos
-				// copylen = 32768 - pos if copylen > 32768 - pos
+				// copylen = dr->lb_capacity - dr->lb_pos if copylen > dr->lb_capacity - dr->lb_pos
+				// copylen = dr->lb_capacity - pos if copylen > dr->lb_capacity - pos
 				dr->copy_len--;
-				int pos = (dr->lb_pos - dr->copy_dist) & 32767;
+				int pos = (dr->lb_pos - dr->copy_dist) & (dr->lb_capacity-1);
 				int token = dr->look_behind[ pos ];
 
 				buf[buf_pos++] = token;
 
 				dr->look_behind[ dr->lb_pos ] = token;
 				dr->lb_pos++;
-				dr->lb_pos &= 32767;
-				if (dr->lb_size < 32768)
+				dr->lb_pos &= (dr->lb_capacity-1);
+				if (dr->lb_size < dr->lb_capacity)
 					dr->lb_size++;
 			}
 			dr->state = LIB_DEFLATE_STATE_HUFFMAN;

--- a/components/driver_framebuffer/png/deflate_reader.c
+++ b/components/driver_framebuffer/png/deflate_reader.c
@@ -173,7 +173,7 @@ lib_deflate_new(lib_reader_read_t read, void *read_p, int lb_capacity)
 		return NULL;
 
 	lib_deflate_init(dr, read, read_p);
-    dr->lb_capacity = lb_capacity;
+	dr->lb_capacity = lb_capacity;
 
 	return dr;
 }

--- a/components/driver_framebuffer/png/deflate_reader.h
+++ b/components/driver_framebuffer/png/deflate_reader.h
@@ -35,8 +35,8 @@ struct lib_deflate_reader {
 
 	bool is_last_block;
 	enum lib_deflate_state_t state;
-	uint8_t look_behind[32768];
 	int lb_size;
+	int lb_capacity;
 	int lb_pos;
 
 	int copy_dist;
@@ -44,9 +44,11 @@ struct lib_deflate_reader {
 
 	uint16_t huffman_lc_tree[288+15];
 	uint16_t huffman_dc_tree[32+15];
+
+	uint8_t look_behind[];
 };
 
-extern struct lib_deflate_reader * lib_deflate_new(lib_reader_read_t read, void *read_p);
+extern struct lib_deflate_reader * lib_deflate_new(lib_reader_read_t read, void *read_p, int lb_capacity);
 extern void lib_deflate_init(struct lib_deflate_reader *dr, lib_reader_read_t read, void *read_p);
 extern ssize_t lib_deflate_read(struct lib_deflate_reader *dr, uint8_t *buf, size_t buf_len);
 extern void lib_deflate_destroy(struct lib_deflate_reader *dr);

--- a/components/driver_framebuffer/png/png_reader.c
+++ b/components/driver_framebuffer/png/png_reader.c
@@ -591,16 +591,18 @@ int lib_png_load_image(Window* window, struct lib_png_reader *pr, uint16_t offse
 	if (res < 2)
 		return -LIB_PNG_ERROR_UNEXPECTED_END_OF_CHUNK;
 
+    int windowsize = 1<<(((rfc1950_hdr[0] & 0xf0)>>4)+8);
 	if ((rfc1950_hdr[0] & 0x0f) != 0x08) // should be deflate algorithm
 		return -LIB_PNG_ERROR_INVALID_DEFLATE_HEADER;
-	if (rfc1950_hdr[0] > 0x78) // max window size is 32 KB
+	if (windowsize > 32768) // max window size is 32 KB
 		return -LIB_PNG_ERROR_INVALID_DEFLATE_HEADER;
 	if (rfc1950_hdr[1] & 0x20) // preset dictionary not allowed
 		return -LIB_PNG_ERROR_INVALID_DEFLATE_HEADER;
 	if (((rfc1950_hdr[0] << 8) + rfc1950_hdr[1]) % 31 != 0) // check checksum
 		return -LIB_PNG_ERROR_INVALID_DEFLATE_HEADER;
 
-	pr->dr = lib_deflate_new((lib_reader_read_t) &lib_png_chunk_read_idat, pr);
+	pr->dr = lib_deflate_new((lib_reader_read_t) &lib_png_chunk_read_idat, pr, windowsize);
+    //printf("allocated deflate with header: %d\n", windowsize);
 	if (pr->dr == NULL)
 		return -LIB_PNG_ERROR_OUT_OF_MEMORY;
 

--- a/components/driver_framebuffer/png/png_reader.c
+++ b/components/driver_framebuffer/png/png_reader.c
@@ -591,7 +591,7 @@ int lib_png_load_image(Window* window, struct lib_png_reader *pr, uint16_t offse
 	if (res < 2)
 		return -LIB_PNG_ERROR_UNEXPECTED_END_OF_CHUNK;
 
-    int windowsize = 1<<(((rfc1950_hdr[0] & 0xf0)>>4)+8);
+	int windowsize = 1<<(((rfc1950_hdr[0] & 0xf0)>>4)+8);
 	if ((rfc1950_hdr[0] & 0x0f) != 0x08) // should be deflate algorithm
 		return -LIB_PNG_ERROR_INVALID_DEFLATE_HEADER;
 	if (windowsize > 32768) // max window size is 32 KB


### PR DESCRIPTION
Modern equivalent of https://github.com/badgeteam/ESP32-platform-firmware/pull/246
The SHA patch works well and applied cleanly, since it's the same code, but haven't verified it on MCH.