### PR TITLE
bug: Unmatched Kconfig values in driver SNDMIXER

### DIFF
--- a/components/driver_sndmixer/Kconfig
+++ b/components/driver_sndmixer/Kconfig
@@ -76,7 +76,7 @@ menu "Driver: Audio mixer"
 
 	choice DRIVER_SNDMIXER_DATA_FORMAT
     		prompt "I2S data format"
-    		default DRIVER_SNDMIXER_DATA_FORMAT_UNSIGNED
+    		default DRIVER_SNDMIXER_I2S_DATA_FORMAT_UNSIGNED
     		depends on DRIVER_SNDMIXER_ENABLE
     	config DRIVER_SNDMIXER_I2S_DATA_FORMAT_UNSIGNED
     		bool "Unsigned integers (e.g. internal DAC)"


### PR DESCRIPTION
This resolves the following warning:

> warning: the default selection DRIVER_SNDMIXER_DATA_FORMAT_UNSIGNED
> (undefined) of <choice DRIVER_SNDMIXER_DATA_FORMAT> (defined at
> components/driver_sndmixer/Kconfig:77) is not contained in the choice

by changing the value `DRIVER_SNDMIXER_DATA_FORMAT_UNSIGNED` to `DRIVER_SNDMIXER_I2S_DATA_FORMAT_UNSIGNED`.