### PR TITLE
(tidy)driver_buses: fix unused variable error

### DIFF
--- a/components/buses/buses.c
+++ b/components/buses/buses.c
@@ -27,7 +27,7 @@ static xSemaphoreHandle i2c1_mux = NULL;
 
 esp_err_t start_buses() {
     // This function initializes the VSPI, HSPI and I2C buses of the ESP32
-    esp_err_t res;
+    esp_err_t res = ESP_OK;
 
     #ifdef CONFIG_BUS_VSPI_ENABLE
         spi_bus_config_t vspiBusConfiguration = {0};
@@ -109,7 +109,7 @@ esp_err_t start_buses() {
         if (i2c1_mux == NULL) return ESP_ERR_NO_MEM;
     #endif
 
-    return ESP_OK;
+    return res;
 }
 
 /* I2C helper functions */


### PR DESCRIPTION
Previously, the `cppcheck` tool reported an error in the `start_buses` function of `buses.c` due to the structure of its macro definitions. The goal was to initialize a value to capture the return state when initializing various buses on the host. If a bus (FOO) was exposed through a macro set by Kconfig, an attempt would be made to initialize the FOO bus. If the attempt failed, the `start_buses` function would immediately return the ESP32 error status from FOO. If the attempts succeeded, `start_buses` would return a static definition of "ESP_OK."

However, the use of macros by the compiler's preprocessor introduced non-determinism for static analysis tools, leading to ambiguity regarding the use of `res`.

This commit slightly changes the behavior by initializing `res` to the desired resulting value, "ESP_OK," and returning `res` instead of "ESP_OK." If any of the buses fail to initialize, the value of `res` will be overwritten, after which the behavior will remain the same.